### PR TITLE
Configure CC to connect to Eirini

### DIFF
--- a/templates/ccng-configmap.yaml
+++ b/templates/ccng-configmap.yaml
@@ -333,10 +333,13 @@ data:
       use_privileged_containers_for_staging: false
 
     opi:
-      url: "https://TODO.TODO"
+      url: "https://eirini.{{ .Release.Namespace }}.svc.cluster.local:8085"
       opi_staging: true
       enabled: true
       cc_uploader_url: "https://TODO.TODO"
+      ca_file: "/config/eirini/certs/tls.ca"
+      client_cert_file: "/config/eirini/certs/tls.crt"
+      client_key_file: "/config/eirini/certs/tls.key"
 
     perm:
       enabled: false

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,8 +53,14 @@ spec:
             mountPath: /data/cloud_controller_ng
           - name: cloud-controller-ng-yaml
             mountPath: /config
-          # - name: uaa-certs
-          #   mountPath: /config/uaa/certs
+          {{- if .Values.uaa_tls_certs_secret_name }}
+          - name: uaa-certs
+            mountPath: /config/uaa/certs
+          {{- end }}
+          {{- if .Values.eirini_tls_certs_secret_name }}
+          - name: eirini-certs
+            mountPath: /config/eirini/certs
+          {{- end }}
         - name: nginx
           image: "nginx"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -86,12 +92,20 @@ spec:
       - name: cloud-controller-ng-yaml
         configMap:
           name: cloud-controller-ng-yaml
-      # TODO: use a single CA for everything plz
-      # - name: uaa-certs
-      #   secret:
-      #     secretName: uaa-certs
       - name: nginx
         configMap:
           name: nginx
       - name: nginx-logs
         emptyDir: {}
+      # TODO: use a single CA for everything plz
+      {{- if .Values.uaa_tls_certs_secret_name }}
+      - name: uaa-certs
+        secret:
+          secretName: {{ .Values.uaa_tls_certs_secret_name }}
+      {{- end }}
+      {{- if .Values.eirini_tls_certs_secret_name }}
+      - name: eirini-certs
+        secret:
+          secretName: {{ .Values.eirini_tls_certs_secret_name }}
+      {{- end }}
+


### PR DESCRIPTION
## Summary
This PR enables the CC to communicate with Eirini.

The PR introduces two new optional helm-configurable values, `uaa_tls_certs_secret_name` and `eirini_tls_certs_secret_name`. If you have UAA and Eirini running on the same cluster and namespace as the CC, these secrets should contain the TLS certs needed to communicate between the CC and these components. If these values are not specified, these secrets won't be mounted in the CC container.

## Verification
We've verified that, when we have eirini and uaa deployed and we set the new `uaa_tls_certs_secret_name` and `eirini_tls_certs_secret_name` helm values, we can push a docker-lifecycle app with `cf push`.

We've also verified that when we follow the README instructions on this repo for deploying this helm chart to a Minikube for development, the CC starts up successfully and curling `v2/info` works (i.e., we don't believe we've broken your development experience).

Thanks!
Jen & @jspawar 