### PR TITLE
Add template for cloud_controller_username_lookup client's secret

### DIFF
--- a/scripts/capi-values.yaml
+++ b/scripts/capi-values.yaml
@@ -13,3 +13,8 @@ blobstore:
   endpoint: http://capi-blobstore-minio.default.svc.cluster.local:9000
   access_key_id: AKIAIOSFODNN7EXAMPLE
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+uaa:
+  clients:
+    cloud_controller_username_lookup:
+      secret: supers3cret

--- a/templates/ccng-configmap.yaml
+++ b/templates/ccng-configmap.yaml
@@ -267,7 +267,7 @@ data:
     uaa_client_scope: openid,cloud_controller_service_permissions.read
 
     cloud_controller_username_lookup_client_name: "cloud_controller_username_lookup"
-    cloud_controller_username_lookup_client_secret: TODO
+    cloud_controller_username_lookup_client_secret: {{ .Values.uaa.clients.cloud_controller_username_lookup.secret }}
 
     cc_service_key_client_name: "cc_service_key_client"
     cc_service_key_client_secret: TODO


### PR DESCRIPTION
- Needed so that CC can use this client to perform successful
`create-org` and `create-space` CF CLI commands
- Also provided a random value for this in the Helm values file used by
the testing deployment scripts