### PR TITLE
Allows the nginx image to be customized

### DIFF
--- a/templates/api_server_deployment.yaml
+++ b/templates/api_server_deployment.yaml
@@ -62,7 +62,7 @@ spec:
             mountPath: /config/eirini/certs
           {{- end }}
         - name: nginx
-          image: "nginx"
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: 80

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,11 @@ image:
   tag: latest
   pullPolicy: Always
 
+nginx:
+  image:
+    repository: "nginx"
+    tag: latest
+
 imagePullSecrets:
 - name: image-registry-credentials
 nameOverride: ""


### PR DESCRIPTION
This allows us to host the nginx image somewhere other than dockerhub. We've done this in a way that it should be non-breaking (i.e., the default image location is still `nginx`).

Thanks,
Jen & @jspawar