### PR TITLE
Fix service selector to only match cloud controller

### DIFF
--- a/templates/api_server_deployment.yaml
+++ b/templates/api_server_deployment.yaml
@@ -13,11 +13,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Chart.Name }}-api-server
+      app.kubernetes.io/name: {{ .Chart.Name }}-api
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Chart.Name }}-api-server
+        app.kubernetes.io/name: {{ .Chart.Name }}-api
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -13,5 +13,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "capi-k8s-release.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}-api


### PR DESCRIPTION
Currently the service in `service.yaml` has a selector which matches `capi`, `worker` and `clock`. Therefore, this service will not work correctly.

After 637aa056 the service selector was no longer matching any of the pods