### PR TITLE
Use https for eirini url

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -326,7 +326,7 @@ diego:
   use_privileged_containers_for_staging: false
 
 opi:
-  url: #@ "http://eirini.{}.svc.cluster.local:8085".format(data.values.namespace)
+  url: #@ "https://eirini.{}.svc.cluster.local:8085".format(data.values.namespace)
   opi_staging: true
   enabled: true
   cc_uploader_url: "https://TODO.TODO"


### PR DESCRIPTION
Hi capi! When we merged your PR: https://github.com/cloudfoundry/cf-for-k8s/pull/14 we ran into app push issues so we took a look at potential changes and found that the communication with eirini was updated from https to http. When we reverted that change, functionality returned to our cf.

In the meantime, we've added an overlay to cf-for-k8s, but wanted to make sure the actual fix made it back to y'all. Feel free to ping us with questions!

Thanks,
Andrew and Dave @davewalter