### PR TITLE
CC worker occasionally fails because of missing certs

### DIFF
--- a/templates/worker_deployment.yml
+++ b/templates/worker_deployment.yml
@@ -27,8 +27,15 @@ spec:
           volumeMounts:
           - name: cloud-controller-ng-yaml
             mountPath: /config
+          #@ if/end data.values.eirini.serverCerts.secretName:
+          - name: eirini-certs
+            mountPath: /config/eirini/certs
       volumes:
       - name: cloud-controller-ng-yaml
         configMap:
           name: cloud-controller-ng-yaml
+      #@ if/end data.values.eirini.serverCerts.secretName:
+      - name: eirini-certs
+        secret:
+          secretName: #@ data.values.eirini.serverCerts.secretName
 


### PR DESCRIPTION
Hi,

We observed failures to delete orgs and associated error logs indicated that the CC worker was attempting to open a CA file for Eirini communication. The corresponding volume mount was missing in this deployment, so we added it in the same way as the API server's deployment.

Interestingly, this error doesn't always occur in our CI. Our test retries the deletion and ends up working after the second delete attempt. 

We have also observed that this error only ever occurs if the org has at least one app in it; if there are no apps in the org we attempt to delete, there are no errors. We suspect this to be the case because deleting an org with an app in it requires communication with Eirini to delete the apps in that org.

Error from CC worker's logs:

> {"timestamp":1581631340.2724764,"message":"Request failed: 500: {\"error_code\"=>\"UnknownError\", \"description\"=>\"An unknown error occurred.\", \"code\"=>10001, \"test_mode_info\"=>{\"description\"=>\"system lib\", \"error_code\"=>\"CF-StoreError\", \"backtrace\"=>[\"/usr/local/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:59:in `add_file'\", \"/usr/local/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:59:in `call'\", \"/usr/local/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:59:in `block (2 levels) in <class:Store>'\", \"/usr/local/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:245:in `add_trust_ca_to_store'\", \"/usr/local/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:236:in `add_trust_ca'\", \"/cloud_controller_ng/lib/cloud_controller/opi/base_client.rb:11:in `initialize'\", \"/cloud_controller_ng/lib/cloud_controller/dependency_locator.rb:419:in `new'\", ...

Thanks,
Jwal + @acosta11 