### PR TITLE
Enable CAPI syncing with Eirini

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -358,7 +358,7 @@ max_retained_deployments_per_app: 100
 max_retained_builds_per_app: 100
 max_retained_revisions_per_app: 100
 diego_sync:
-  frequency_in_seconds: 0
+  frequency_in_seconds: 1
 pending_builds:
   frequency_in_seconds: 300
   expiration_in_seconds: 42


### PR DESCRIPTION
Diego_sync also does sync with  Eirini. It has to be enabled to work.