### PR TITLE
Metric proxy

### DIFF
--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -44,6 +44,9 @@ spec:
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
+          #@ if/end data.values.metric_proxy.serverCerts.secretName:
+          - name: metric-proxy-certs
+            mountPath: /config/metric_proxy/certs
         - name: capi-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
@@ -89,6 +92,10 @@ spec:
       - name: eirini-certs
         secret:
           secretName: #@ data.values.eirini.serverCerts.secretName
+      #@ if/end data.values.metric_proxy.serverCerts.secretName:
+      - name: metric-proxy-certs
+        secret:
+          secretName: #@ data.values.metric_proxy.serverCerts.secretName
       - name: nginx-uploads
         emptyDir: {}
 

--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -44,10 +44,10 @@ spec:
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
-          #@ if/end data.values.metric_proxy.tls_secret:
+          #@ if/end data.values.metric_proxy.cert.secret_name:
           - name: metric-proxy-certs
             mountPath: /config/metric_proxy/certs
-          #@ if/end data.values.metric_proxy.ca_secret:
+          #@ if/end data.values.metric_proxy.ca.secret_name:
           - name: metric-proxy-ca
             mountPath: /config/metric_proxy/ca
         - name: capi-local-worker
@@ -95,14 +95,14 @@ spec:
       - name: eirini-certs
         secret:
           secretName: #@ data.values.eirini.serverCerts.secretName
-      #@ if/end data.values.metric_proxy.tls_secret:
+      #@ if/end data.values.metric_proxy.cert.secret_name:
       - name: metric-proxy-certs
         secret:
-          secretName: #@ data.values.metric_proxy.tls_secret
-      - name: nginx-uploads
-        emptyDir: {}
-      #@ if/end data.values.metric_proxy.ca_secret:
+          secretName: #@ data.values.metric_proxy.cert.secret_name
+      #@ if/end data.values.metric_proxy.ca.secret_name:
       - name: metric-proxy-ca
         secret:
-          secretName: #@ data.values.metric_proxy.ca_secret
+          secretName: #@ data.values.metric_proxy.ca.secret_name
+      - name: nginx-uploads
+        emptyDir: {}
 

--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -44,9 +44,12 @@ spec:
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
-          #@ if/end data.values.metric_proxy.serverCerts.secretName:
+          #@ if/end data.values.metric_proxy.tls_secret:
           - name: metric-proxy-certs
             mountPath: /config/metric_proxy/certs
+          #@ if/end data.values.metric_proxy.ca_secret:
+          - name: metric-proxy-ca
+            mountPath: /config/metric_proxy/ca
         - name: capi-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
@@ -92,10 +95,14 @@ spec:
       - name: eirini-certs
         secret:
           secretName: #@ data.values.eirini.serverCerts.secretName
-      #@ if/end data.values.metric_proxy.serverCerts.secretName:
+      #@ if/end data.values.metric_proxy.tls_secret:
       - name: metric-proxy-certs
         secret:
-          secretName: #@ data.values.metric_proxy.serverCerts.secretName
+          secretName: #@ data.values.metric_proxy.tls_secret
       - name: nginx-uploads
         emptyDir: {}
+      #@ if/end data.values.metric_proxy.ca_secret:
+      - name: metric-proxy-ca
+        secret:
+          secretName: #@ data.values.metric_proxy.ca_secret
 

--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -86,8 +86,8 @@ logcache:
   temporary_ignore_server_unavailable_errors: true
 
 logcache_tls:
-  #@ if data.values.metric_proxy.tls_secret:
-  ca_file: "/config/metric_proxy_ca/ca/tls.crt"
+  #@ if data.values.metric_proxy.cert.secret_name:
+  ca_file: "/config/metric_proxy/ca/tls.crt"
   cert_file: "/config/metric_proxy/certs/tls.crt"
   key_file: "/config/metric_proxy/certs/tls.key"
   #@ else:

--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -86,9 +86,15 @@ logcache:
   temporary_ignore_server_unavailable_errors: true
 
 logcache_tls:
-  ca_file: "/config/metric_proxy_ca/certs/tls.ca"
+  #@ if data.values.metric_proxy.tls_secret:
+  ca_file: "/config/metric_proxy_ca/ca/tls.crt"
   cert_file: "/config/metric_proxy/certs/tls.crt"
   key_file: "/config/metric_proxy/certs/tls.key"
+  #@ else:
+  ca_file: "/dev/null"
+  cert_file: "/dev/null"
+  key_file: "/dev/null"
+  #@ end
   subject_name: metric-proxy
 
 loggregator:

--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -81,15 +81,15 @@ logging:
   max_retries: 1
 
 logcache:
-  host: #@ "https://log-cache.{}".format(data.values.system_domain)
+  host: metric-proxy
   port: 8080
   temporary_ignore_server_unavailable_errors: true
 
 logcache_tls:
-  key_file: "/dev/null"
-  cert_file: "/dev/null"
-  ca_file: "/dev/null"
-  subject_name: log_cache
+  ca_file: "/config/metric_proxy_ca/certs/tls.ca"
+  cert_file: "/config/metric_proxy/certs/tls.crt"
+  key_file: "/config/metric_proxy/certs/tls.key"
+  subject_name: metric-proxy
 
 loggregator:
   router: 127.0.0.1:3457

--- a/values.yml
+++ b/values.yml
@@ -44,6 +44,10 @@ eirini:
   serverCerts:
     secretName:
 
+metric_proxy:
+  serverCerts:
+    secretName:
+
 apiServer:
   opi:  #! these certs were manually generated for dev purposes, they are not real eirini certs and don't have SANs.
     client_key: |

--- a/values.yml
+++ b/values.yml
@@ -45,8 +45,10 @@ eirini:
     secretName:
 
 metric_proxy:
-  tls_secret:
-  ca_secret:
+  ca:
+    secret_name:
+  cert:
+    secret_name:
 
 apiServer:
   opi:  #! these certs were manually generated for dev purposes, they are not real eirini certs and don't have SANs.

--- a/values.yml
+++ b/values.yml
@@ -45,8 +45,8 @@ eirini:
     secretName:
 
 metric_proxy:
-  serverCerts:
-    secretName:
+  tls_secret:
+  ca_secret:
 
 apiServer:
   opi:  #! these certs were manually generated for dev purposes, they are not real eirini certs and don't have SANs.


### PR DESCRIPTION
The metrics-egress team has added a new service called metric-proxy that replaces logcache in cf-for-k8s for all metrics usage. It fetches metrics from the kubelet and matches the logcache api in capi. 