### PR TITLE
Fix log-cache URL in CC / endpoint response

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -126,7 +126,7 @@ db: &db
 
 telemetry_log_path: "/dev/null"
 log_cache:
-  url: #@ "log-cache.{}".format(data.values.system_domain)
+  url: #@ "https://log-cache.{}".format(data.values.system_domain)
 threadpool_size: 20
 internal_route_vip_range: ""
 


### PR DESCRIPTION
This change ensures that CC's / endpoint provides the "https" scheme in
the log_cache href field, so that CF CLI v6.50.0 and later can connect
to the log-cache service correctly. This change also matches the
[URL value present in the CAPI BOSH release](https://github.com/cloudfoundry/capi-release/blob/1.92.0/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb#L160).

Additionally, this change reverts #14, the previous attempt to
correct this endpoint response value, restoring it to the same kind of
[scheme-less host value that is present in the CAPI BOSH release](https://github.com/cloudfoundry/capi-release/blob/1.92.0/jobs/cloud_controller_ng/spec#L1091-L1093).