### PR TITLE
Update ccng-config.lib.yml

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -55,7 +55,7 @@ nginx:
 index: 0
 name: ""
 route_services_enabled: true
-volume_services_enabled: false
+volume_services_enabled: true
 
 info:
   name: ""


### PR DESCRIPTION
The volume services team would like to default this value to true in the k8s distribution. We added this switch to ccng years ago when diego volume services were still highly experimental, but it doesn't really need to default to false anymore.

Since this config gets injected into the kubernetes configuration as a great big string, it's quite difficult for us to manipulate these values with ytt overlays, which means that if we want to change this value we have to resort to [dirty hacks like this](https://github.com/cloudfoundry/smb-volume-k8s-local-cluster/blob/6f5f0ef022065842d30c671174bce69e12ebb06b/cf-on-kind/deploy.sh#L11).  Defaulting `volume_services_enabled` to true would allow us to stop using `sed` for interpolation.