### PR TITLE
Bump builder image to 0.0.94

### DIFF
--- a/templates/cf-autodetect-builder.yml
+++ b/templates/cf-autodetect-builder.yml
@@ -11,4 +11,4 @@ metadata:
   name: cf-autodetect-builder
   namespace: #@ data.values.staging_namespace
 spec:
-  image: cloudfoundry/cnb:0.0.55-bionic
+  image: #@ data.values.images.cf_autodetect_builder

--- a/values.yml
+++ b/values.yml
@@ -7,6 +7,7 @@ images:
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
+  cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
 system_namespace: cf-system
 workloads_namespace: cf-workloads
 staging_namespace: cf-workloads-staging


### PR DESCRIPTION
Now that cf-for-k8s is using kpack 0.0.8 https://github.com/cloudfoundry/cf-for-k8s/pull/126

The builder image can be updated to a more recent version.