### PR TITLE
Communications between system components and resources should use internal DNS

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -99,7 +99,7 @@ logcache_tls:
 
 loggregator:
   router: 127.0.0.1:3457
-  internal_url: #@ "https://log-api.{}:8081".format(data.values.system_domain)
+  internal_url: #@ "https://log-api.{}.svc.cluster.local:8081".format(data.values.system_namespace)
 log_stream:
   url: #@ "https://log-stream.{}".format(data.values.system_domain)
 


### PR DESCRIPTION
- Ensure the internal loggregator URL is actually internal.  The capi
  job spec uses a bosh internal URL; this is the cf-for-k8s internal URL.

[#171007126](https://www.pivotaltracker.com/story/show/171007126)

Signed-off-by: Dave Walter <dwalter@pivotal.io>