### PR TITLE
Use the internal loggregator URL

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -99,7 +99,7 @@ logcache_tls:
 
 loggregator:
   router: 127.0.0.1:3457
-  internal_url: #@ "https://log-api.{}:8081".format(data.values.system_domain)
+  internal_url: #@ "https://log-api.{}.svc.cluster.local:8081".format(data.values.system_namespace)
 log_stream:
   url: #@ "https://log-stream.{}".format(data.values.system_domain)
 


### PR DESCRIPTION
- matches the default in the capi-release job spec

[#171007126](https://www.pivotaltracker.com/story/show/171007126)

Signed-off-by: Eric Promislow <epromislow@suse.com>