### PR TITLE
Make blobstore provider configurable

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -173,14 +173,7 @@ default_quota_definition: default
 resource_pool:
   resource_directory_key: #@ data.values.blobstore.resource_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
   minimum_size: 65536
   maximum_size: 536870912
 
@@ -194,14 +187,7 @@ resource_pool:
 packages:
   app_package_directory_key: #@ data.values.blobstore.package_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
   max_valid_packages_stored: 5
   max_package_size: 1073741824
 
@@ -215,14 +201,7 @@ packages:
 droplets:
   droplet_directory_key: #@ data.values.blobstore.droplet_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
 
   cdn:
     uri:
@@ -235,14 +214,7 @@ droplets:
 buildpacks:
   buildpack_directory_key: #@ data.values.blobstore.buildpack_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
 
   cdn:
     uri:

--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data","data")
+#@ load("fog-connection.lib.yml","fog_connection")
 #@ def ccng_config():
 ---
 local_route: 0.0.0.0

--- a/templates/fog-connection.lib.yml
+++ b/templates/fog-connection.lib.yml
@@ -1,0 +1,30 @@
+#@ load("@ytt:data","data")
+#@ load("@ytt:assert","assert")
+
+#@ def fog_connection():
+#@ if data.values.blobstore.provider == "Minio":
+provider: #@ data.values.blobstore.provider
+endpoint: #@ data.values.blobstore.endpoint
+aws_access_key_id: #@ data.values.blobstore.access_key_id
+aws_secret_access_key: #@ data.values.blobstore.secret_access_key
+aws_signature_version: '2'
+region: ""
+path_style: true
+#@ elif data.values.blobstore.provider == "AWS":
+provider: #@ data.values.blobstore.provider
+endpoint: #@ data.values.blobstore.endpoint
+aws_access_key_id: #@ data.values.blobstore.access_key_id
+aws_secret_access_key: #@ data.values.blobstore.secret_access_key
+aws_signature_version: '2'
+region: #@ data.values.blobstore.region if data.values.blobstore.region else ""
+path_style: true
+#@ elif data.values.blobstore.provider == "Google":
+provider: #@ data.values.blobstore.provider
+google_project: #@ data.values.blobstore.google_project
+google_client_email: #@ data.values.blobstore.google_client_email
+google_json_key_string: #@ data.values.blobstore.google_json_key_string
+#@ else:
+  #@ assert.fail("blobstore provider must be Minio, AWS or Google.")
+#@ end
+
+#@ end

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -66,12 +66,13 @@ apiServer:
       -----END RSA PRIVATE KEY-----
 app_domains: []
 blobstore:
+  provider: Minio
   access_key_id: AKIAIOSFODNN7EXAMPLE
   buildpack_directory_key: cc-buildpacks
   droplet_directory_key: cc-droplets
   endpoint: http://capi-blobstore-minio.default:9000
   package_directory_key: cc-packages
-  region: ""
+  region: ~
   resource_directory_key: cc-resources
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ccdb:


### PR DESCRIPTION
This PR adds the ability to use GCP, AWS, or Minio by
specifying the provider in values.yml

Changed the default `region` to be `~` (nil) as setting it
as an empty string can cause it to escape the quotes each time
its processed. for example its turned into `''''''` by the time its
passed through the fog lib.

the new fog lib will convert the nil char to an empty string as required.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>