### PR TITLE
Change kpack registry repository key

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -364,7 +364,7 @@ kubernetes:
   kpack:
     builder_namespace: #@ data.values.staging_namespace
     registry_service_account_name: cc-kpack-registry-service-account
-    registry_tag_base: #@ data.values.kpack.registry.repository
+    registry_tag_base: #@ data.values.kpack.registry.repository_prefix
 
 #! worker property
 perform_blob_cleanup: true

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -89,7 +89,7 @@ kpack:
   registry:
     hostname: ""
     password: ""
-    repository: ""
+    repository_prefix: ""
     username: ""
 metric_proxy:
   ca:


### PR DESCRIPTION
Related to [issue #249 in cf-for-k8s](https://github.com/cloudfoundry/cf-for-k8s/issues/249). There will be a parallel PR for cf-for-k8s once this has been updated.

- Change from repository to repository_prefix

Signed-off-by: Eric Promislow <epromislow@suse.com>