### PR TITLE
Remove certs for metric proxy

### DIFF
--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -43,12 +43,6 @@ spec:
           #@ if/end data.values.ccdb.ca_cert:
           - name: database-ca-cert
             mountPath: /config/database/certs
-          #@ if/end data.values.metric_proxy.cert.secret_name:
-          - name: metric-proxy-certs
-            mountPath: /config/metric_proxy/certs
-          #@ if/end data.values.metric_proxy.ca.secret_name:
-          - name: metric-proxy-ca
-            mountPath: /config/metric_proxy/ca
         - name: cf-api-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
@@ -108,14 +102,6 @@ spec:
       - name: database-ca-cert
         secret:
           secretName: database-ca-cert
-      #@ if/end data.values.metric_proxy.cert.secret_name:
-      - name: metric-proxy-certs
-        secret:
-          secretName: #@ data.values.metric_proxy.cert.secret_name
-      #@ if/end data.values.metric_proxy.ca.secret_name:
-      - name: metric-proxy-ca
-        secret:
-          secretName: #@ data.values.metric_proxy.ca.secret_name
       - name: nginx-uploads
         emptyDir: {}
 

--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -89,18 +89,6 @@ logcache:
   port: 8080
   temporary_ignore_server_unavailable_errors: true
 
-logcache_tls:
-  #@ if data.values.metric_proxy.cert.secret_name:
-  ca_file: "/config/metric_proxy/ca/tls.crt"
-  cert_file: "/config/metric_proxy/certs/tls.crt"
-  key_file: "/config/metric_proxy/certs/tls.key"
-  #@ else:
-  ca_file: "/dev/null"
-  cert_file: "/dev/null"
-  key_file: "/dev/null"
-  #@ end
-  subject_name: metric-proxy
-
 log_stream:
   url: #@ "https://log-stream.{}".format(data.values.system_domain)
 

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -92,11 +92,6 @@ kpack:
     password: ""
     repository_prefix: ""
     username: ""
-metric_proxy:
-  ca:
-    secret_name: null
-  cert:
-    secret_name: null
 replicaCount: 1
 staging_namespace: cf-workloads-staging
 system_domain: cf-system.svc.cluster.local


### PR DESCRIPTION
* This will be handled by Istio
* This requires new images of cloud_controller_ng after this PR:
https://github.com/cloudfoundry/cloud_controller_ng/pull/1731

[#173597144]

Signed-off-by: Louie Brann <lbrann@pivotal.io>


NOTE: This requires changes after merging in as it needs an updated cloud_controller_ng from the PR linked above