### PR TITLE
more renaming of cf-api-kpack-watcher -> cf-api-controllers

### DIFF
--- a/dev-templates/_dev-values.yml
+++ b/dev-templates/_dev-values.yml
@@ -3,7 +3,7 @@
 kbld:
   destination:
     ccng: ""
-    capi_kpack_watcher: ""
+    cf_api_controllers: ""
 src_dirs:
   ccng: ""
-  capi_kpack_watcher: ""
+  cf_api_controllers: ""

--- a/dev-templates/kbld.yml
+++ b/dev-templates/kbld.yml
@@ -8,15 +8,15 @@ sources:
   - imageRepo: #@ data.values.kbld.destination.ccng
     path: #@ data.values.src_dirs.ccng
   - imageRepo: cloudfoundry/capi-kpack-watcher
-    path: #@ data.values.src_dirs.capi_kpack_watcher
+    path: #@ data.values.src_dirs.cf_api_controllers
     pack:
       build:
-        builder: cloudfoundry/cnb:bionic
-  - imageRepo: #@ data.values.kbld.destination.capi_kpack_watcher
-    path: #@ data.values.src_dirs.capi_kpack_watcher
+        builder: gcr.io/paketo-buildpacks/builder:full-cf
+  - imageRepo: #@ data.values.kbld.destination.cf_api_controllers
+    path: #@ data.values.src_dirs.cf_api_controllers
     pack:
       build:
-        builder: cloudfoundry/cnb:bionic
+        builder: gcr.io/paketo-buildpacks/builder:full-cf
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: ImageDestinations
@@ -26,15 +26,15 @@ destinations:
   - imageRepo: #@ data.values.kbld.destination.ccng
     newImage: #@ data.values.kbld.destination.ccng
   - imageRepo: cloudfoundry/capi-kpack-watcher
-    newImage: #@ data.values.kbld.destination.capi_kpack_watcher
-  - imageRepo: #@ data.values.kbld.destination.capi_kpack_watcher
-    newImage: #@ data.values.kbld.destination.capi_kpack_watcher
+    newImage: #@ data.values.kbld.destination.cf_api_controllers
+  - imageRepo: #@ data.values.kbld.destination.cf_api_controllers
+    newImage: #@ data.values.kbld.destination.cf_api_controllers
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: ImageKeys
 keys:
 - ccng
-- capi_kpack_watcher
+- cf_api_controllers
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: Config

--- a/scripts/build-into-values.sh
+++ b/scripts/build-into-values.sh
@@ -7,11 +7,11 @@ REPO_BASE_DIR="${SCRIPT_DIR}/.."
 
 # set defaults - any of these should be configrable from outside this script
 IMAGE_DESTINATION_CCNG="${IMAGE_DESTINATION_CCNG:-gcr.io/cf-capi-arya/dev-ccng}"
-IMAGE_DESTINATION_KPACK_WATCHER="${IMAGE_DESTINATION_KPACK_WATCHER:-gcr.io/cf-capi-arya/dev-kpack-watcher}"
+IMAGE_DESTINATION_CF_API_CONTROLLERS="${IMAGE_DESTINATION_CF_API_CONTROLLERS:-gcr.io/cf-capi-arya/dev-controllers}"
 CF_FOR_K8s_DIR="${CF_FOR_K8s_DIR:-${HOME}/workspace/cf-for-k8s/}"
 CAPI_RELEASE_DIR="${CAPI_RELEASE_DIR:-${HOME}/workspace/capi-release/}"
 CCNG_DIR="${CAPI_RELEASE_DIR}src/cloud_controller_ng"
-CAPI_KPACK_WATCHER_DIR="${CAPI_KPACK_WATCHER_DIR:-${REPO_BASE_DIR}/src/cf-api-controllers}"
+CF_API_CONTROLLERS_DIR="${CAPI_CF_API_CONTROLLERS_DIR:-${REPO_BASE_DIR}/src/cf-api-controllers}"
 
 if [ -z "$1" ]
   then
@@ -22,10 +22,10 @@ fi
 # template the image destination into the kbld yml
 KBLD_TMP="$(mktemp)"
 ytt -f "${REPO_BASE_DIR}/dev-templates/" \
-    -v kbld.destination.ccng="${IMAGE_DESTINATION_CCNG}" \
-    -v kbld.destination.capi_kpack_watcher="${IMAGE_DESTINATION_KPACK_WATCHER}" \
-    -v src_dirs.ccng="${CCNG_DIR}" \
-    -v src_dirs.capi_kpack_watcher="${CAPI_KPACK_WATCHER_DIR}" \
+    -v "kbld.destination.ccng=${IMAGE_DESTINATION_CCNG}" \
+    -v "kbld.destination.cf_api_controllers=${IMAGE_DESTINATION_CF_API_CONTROLLERS}" \
+    -v "src_dirs.ccng=${CCNG_DIR}" \
+    -v "src_dirs.cf_api_controllers=${CF_API_CONTROLLERS_DIR}" \
      > "${KBLD_TMP}"
 
 # build a new values file with kbld

--- a/templates/controllers_deployment.yml
+++ b/templates/controllers_deployment.yml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cf-api-kpack-watcher
+  name: cf-api-controllers
   namespace: #@ data.values.system_namespace
   labels:
-    app.kubernetes.io/name: cf-api-kpack-watcher
-    app.kubernetes.io/instance: cf-api-kpack-watcher-0
+    app.kubernetes.io/name: cf-api-controllers
+    app.kubernetes.io/instance: cf-api-controllers-0
 spec:
   replicas: 1
   strategy:
@@ -16,16 +16,16 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: cf-api-kpack-watcher
+      app.kubernetes.io/name: cf-api-controllers
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: cf-api-kpack-watcher
+        app.kubernetes.io/name: cf-api-controllers
     spec:
-      serviceAccountName: cf-api-kpack-watcher-service-account
+      serviceAccountName: cf-api-controllers-service-account
       containers:
       - name: manager
-        image: #@ data.values.images.capi_kpack_watcher
+        image: #@ data.values.images.cf_api_controllers
         env:
         - name: UAA_CLIENT_SECRET
           value: #@ data.values.uaa.clients.capi_kpack_watcher.secret
@@ -49,7 +49,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kpack-watcher
+  name: cf-api-controllers
 rules:
 - apiGroups: ["build.pivotal.io"]
   resources: ["images", "builds", "builds/status", "images/status"]
@@ -58,12 +58,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kpack-watcher-binding
+  name: controllers-binding
 subjects:
 - kind: ServiceAccount
   namespace: #@ data.values.system_namespace
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
 roleRef:
   kind: ClusterRole
-  name: kpack-watcher
+  name: cf-api-controllers
   apiGroup: rbac.authorization.k8s.io

--- a/templates/controllers_deployment.yml
+++ b/templates/controllers_deployment.yml
@@ -28,11 +28,11 @@ spec:
         image: #@ data.values.images.cf_api_controllers
         env:
         - name: UAA_CLIENT_SECRET
-          value: #@ data.values.uaa.clients.capi_kpack_watcher.secret
+          value: #@ data.values.uaa.clients.cf_api_controllers.secret
         - name: UAA_ENDPOINT
           value: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
         - name: UAA_CLIENT_NAME
-          value: capi_kpack_watcher
+          value: cf_api_controllers
         - name: CF_API_HOST
           value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
         - name: STAGING_NAMESPACE

--- a/templates/service-accounts.yml
+++ b/templates/service-accounts.yml
@@ -127,13 +127,11 @@ roleRef:
   kind: ClusterRole
   name: "cf:kpack-builds-admin"
   apiGroup: rbac.authorization.k8s.io
-
-#! kpack watcher service account
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,11 +163,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-kpack-watcher-service-account-kpack-builds-reader
+  name: cf-api-controllers-service-account-kpack-builds-reader
   namespace: #@ data.values.staging_namespace
 subjects:
 - kind: ServiceAccount
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole
@@ -179,11 +177,11 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-kpack-watcher-service-account-service-accounts-secrets-fetcher
+  name: cf-api-controllers-service-account-service-accounts-secrets-fetcher
   namespace: #@ data.values.staging_namespace
 subjects:
 - kind: ServiceAccount
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -103,7 +103,7 @@ system_domain: cf-system.svc.cluster.local
 system_namespace: cf-system
 uaa:
   clients:
-    capi_kpack_watcher:
+    cf_api_controllers:
       secret: supers3cret
     cloud_controller_username_lookup:
       secret: supers3cret

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -111,7 +111,7 @@ uaa:
     secretName: null
 workloads_namespace: cf-workloads
 images:
-  capi_kpack_watcher:
+  cf_api_controllers:
   ccng:
   cf_autodetect_builder:
   nginx:

--- a/values/images.yml
+++ b/values/images.yml
@@ -1,7 +1,7 @@
 #@data/values
 ---
 images:
-  capi_kpack_watcher: cloudfoundry/capi-kpack-watcher@sha256:954144ec4062df8913db4d1b3c1cc0330753bafcfd57f11e564b8f34e48a7265
+  cf_api_controllers: cloudfoundry/capi-kpack-watcher@sha256:954144ec4062df8913db4d1b3c1cc0330753bafcfd57f11e564b8f34e48a7265
   ccng: cloudfoundry/cloud-controller-ng@sha256:fe904a2810a6330586a23d4e0e2c607aa95f17ed62d17cc29244ef7f6e9f33b5
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
   nginx: cloudfoundry/capi-nginx@sha256:980f50e190cbff72d23300bc422da23faa888271c2d07ac3abaa65af55a5316a


### PR DESCRIPTION
- in accordance with https://github.com/cloudfoundry/capi-k8s-release/blob/master/decisions/0003-cf-api-controller-repo.md
- secrets in cf-for-k8s are still not working

Authored-by: Connor Braa <cbraa@pivotal.io>