### PR TITLE
External blobstore preparations

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -179,7 +179,7 @@ resource_pool:
     provider: AWS
     endpoint: #@ data.values.blobstore.endpoint
     aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_signature_version: '2'
+    aws_signature_version: #@ data.values.blobstore.aws_signature_version
     region: #@ data.values.blobstore.region
     path_style: true
   minimum_size: 65536
@@ -199,7 +199,7 @@ packages:
     provider: AWS
     endpoint: #@ data.values.blobstore.endpoint
     aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_signature_version: '2'
+    aws_signature_version: #@ data.values.blobstore.aws_signature_version
     region: #@ data.values.blobstore.region
     path_style: true
   max_valid_packages_stored: 5
@@ -219,7 +219,7 @@ droplets:
     provider: AWS
     endpoint: #@ data.values.blobstore.endpoint
     aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_signature_version: '2'
+    aws_signature_version: #@ data.values.blobstore.aws_signature_version
     region: #@ data.values.blobstore.region
     path_style: true
 
@@ -238,7 +238,7 @@ buildpacks:
     provider: AWS
     endpoint: #@ data.values.blobstore.endpoint
     aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_signature_version: '2'
+    aws_signature_version: #@ data.values.blobstore.aws_signature_version
     region: #@ data.values.blobstore.region
     path_style: true
 

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -71,6 +71,7 @@ blobstore:
   droplet_directory_key: cc-droplets
   endpoint: http://capi-blobstore-minio.default:9000
   package_directory_key: cc-packages
+  aws_signature_version: '2'
   region: ""
   resource_directory_key: cc-resources
   secret_access_key_secret_name:


### PR DESCRIPTION
This is the first step in a series to support external blobstores and allows the `aws_signature_version` setting to be configured. 
See [#344](https://github.com/cloudfoundry/cf-for-k8s/issues/344) for more details.

@Haegi
