### PR TITLE
Set memory and cpu requests and limit values for all containers

### DIFF
--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -39,8 +39,10 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
+              cpu: 500m
               memory: 300Mi
             limits:
+              cpu: 1000m
               memory: 1.2Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
@@ -67,8 +69,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 100m
               memory: 300Mi
             limits:
+              cpu: 500m
               memory: 1.2Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
@@ -86,6 +90,13 @@ spec:
             httpGet:
               port: 80
               path: "/healthz"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           volumeMounts:
           - name: nginx
             mountPath: /etc/nginx
@@ -101,6 +112,13 @@ spec:
           - containerPort: 9102
           image: #@ data.values.images.statsd_exporter
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
       serviceAccountName: cf-api-server-service-account
       volumes:
       - #@ template.replace(shared_config_volumes())

--- a/templates/clock_deployment.yml
+++ b/templates/clock_deployment.yml
@@ -40,7 +40,7 @@ spec:
               cpu: 300m
               memory: 300Mi
             limits:
-              cpu: 600m
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/templates/clock_deployment.yml
+++ b/templates/clock_deployment.yml
@@ -37,8 +37,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 300m
               memory: 300Mi
             limits:
+              cpu: 600m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/templates/deployment_updater_deployment.yml
+++ b/templates/deployment_updater_deployment.yml
@@ -40,7 +40,7 @@ spec:
               cpu: 300m
               memory: 300Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/templates/deployment_updater_deployment.yml
+++ b/templates/deployment_updater_deployment.yml
@@ -37,8 +37,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 300m
               memory: 300Mi
             limits:
+              cpu: 500m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/templates/worker_deployment.yml
+++ b/templates/worker_deployment.yml
@@ -33,8 +33,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 100m
               memory: 300Mi
             limits:
+              cpu: 500m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/templates/worker_deployment.yml
+++ b/templates/worker_deployment.yml
@@ -33,10 +33,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
-              cpu: 100m
+              cpu: 300m
               memory: 300Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:


### PR DESCRIPTION
Relint is currently working on a scaling and Quality of Service (QoS) set of stories.

We are targeting 1.0 to be configured out-of-the-box as a "developer" edition aimed at those users who want to kick the tyres.  As part of this, we would like to set limits on mem/cpu.

Since a "developer" edition may not be preferred by everyone, we want each component to be configurable to scale both horizontally (replicas) and vertically (mem/cpu).  This will also allow users to deliver a Guaranteed QoS when required (although we are recommending that all of our pods and containers use the Burstable QoS) As part of this we would like to ask you to do several things:

1. consider which of your pods/containers you would like to expose for scaling properties for.
2. expose said configuration properties.
3. sets mem and cpu values for all containers in order to provide as much meta-data to k8s as possible so that its scheduler can do as good a job as possible. This PR is an initial attempt at setting these values, although we know you are much more likely to have insight into your components mem/cpu requirements than our guess.  

If you have any questions or concerns, please let us know! Thanks! 

[#174462927](https://www.pivotaltracker.com/story/show/174462927)

Co-Authored-By: Angela Chin <achin@pivotal.io>