### PR TITLE
refactor config loading / validation in cf-api-controllers

### DIFF
--- a/src/cf-api-controllers/cf/auth/uaa.go
+++ b/src/cf-api-controllers/cf/auth/uaa.go
@@ -1,10 +1,8 @@
 package auth
 
 import (
+	"code.cloudfoundry.org/capi-k8s-release/src/cf-api-controllers/cfg"
 	"context"
-	"io/ioutil"
-	"os"
-
 	uaaClient "github.com/cloudfoundry-community/go-uaa"
 )
 
@@ -20,14 +18,10 @@ func (u *UAAClient) Fetch() (string, error) {
 }
 
 // NewUAAClient creates a new UAA client.
-// The following environment variables must be set:
-//   UAA_CLIENT_NAME: Name of client inside UAA (e.g. in CF, this is configured on the UAA job in a BOSH manifest).
-//	 UAA_CLIENT_SECRET: Secret generated for the client in UAA, similar to above.
-//	 UAA_ENDPOINT: The FQDN of UAA (e.g. https://uaa.katniss.capi.land)
-func NewUAAClient() *UAAClient {
+func NewUAAClient(config *cfg.Config) *UAAClient {
 	client, err := uaaClient.New(
-		os.Getenv("UAA_ENDPOINT"),
-		uaaClient.WithClientCredentials(os.Getenv("UAA_CLIENT_NAME"), uaaClientSecret(), 1),
+		config.UAAEndpoint(),
+		uaaClient.WithClientCredentials(config.UAAClientName(), config.UAAClientSecret(), 1),
 		uaaClient.WithSkipSSLValidation(true),
 	)
 	if err != nil {
@@ -35,18 +29,6 @@ func NewUAAClient() *UAAClient {
 	}
 
 	return &UAAClient{client}
-}
-
-func uaaClientSecret() string {
-	if os.Getenv("UAA_CLIENT_SECRET_FILE") != "" {
-		contents, err := ioutil.ReadFile(os.Getenv("UAA_CLIENT_SECRET_FILE"))
-		if err != nil {
-			panic(err)
-		}
-		return string(contents)
-	}
-
-	return os.Getenv("UAA_CLIENT_SECRET")
 }
 
 // UAAClient wraps over the official UAA client implementation.

--- a/src/cf-api-controllers/cfg/cfg_suite_test.go
+++ b/src/cf-api-controllers/cfg/cfg_suite_test.go
@@ -1,0 +1,15 @@
+package cfg_test
+
+import (
+	"github.com/matt-royal/biloba"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCfg(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t, "Cfg Suite", biloba.GoLandReporter())
+}

--- a/src/cf-api-controllers/cfg/config.go
+++ b/src/cf-api-controllers/cfg/config.go
@@ -1,0 +1,87 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+type Config struct {
+	cfAPIHost          string
+	uaaEndpoint        string
+	uaaClientName      string
+	uaaClientSecret    string
+	workloadsNamespace string
+}
+
+func Load() (*Config, error) {
+	c := &Config{}
+
+	if c.cfAPIHost = os.Getenv("CF_API_HOST"); c.cfAPIHost == "" {
+		return nil, envNotSetErr("CF_API_HOST")
+	}
+
+	if c.uaaEndpoint = os.Getenv("UAA_ENDPOINT"); c.uaaEndpoint == "" {
+		return nil, envNotSetErr("UAA_ENDPOINT")
+	}
+
+	if c.uaaClientName = os.Getenv("UAA_CLIENT_NAME"); c.uaaClientName == "" {
+		return nil, envNotSetErr("UAA_CLIENT_NAME")
+	}
+
+	if c.workloadsNamespace = os.Getenv("WORKLOADS_NAMESPACE"); c.workloadsNamespace == "" {
+		return nil, envNotSetErr("WORKLOADS_NAMESPACE")
+	}
+
+	var err error
+	c.uaaClientSecret, err = c.fetchUaaClientSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Config) CFAPIHost() string {
+	return c.cfAPIHost
+}
+
+func (c *Config) UAAEndpoint() string {
+	return c.uaaEndpoint
+}
+
+func (c *Config) UAAClientName() string {
+	return c.uaaClientName
+}
+
+func (c *Config) UAAClientSecret() string {
+	return c.uaaClientSecret
+}
+
+func (c *Config) WorkloadsNamespace() string {
+	return c.workloadsNamespace
+}
+
+func (c *Config) fetchUaaClientSecret() (string, error) {
+	secretFile := os.Getenv("UAA_CLIENT_SECRET_FILE")
+	if secretFile == "" {
+		secretEnv := os.Getenv("UAA_CLIENT_SECRET")
+		if secretEnv == "" {
+			return "", errors.New("`UAA_CLIENT_SECRET_FILE` or `UAA_CLIENT_SECRET` environment variable must be set")
+		}
+
+		return secretEnv, nil
+	}
+
+	secretBytes, err := ioutil.ReadFile(secretFile)
+	if err != nil {
+		return "", err
+	}
+
+	return string(secretBytes), nil
+}
+
+func envNotSetErr(e string) error {
+	return errors.New(fmt.Sprintf("`%s` environment variable must be set", e))
+}

--- a/src/cf-api-controllers/cfg/config_test.go
+++ b/src/cf-api-controllers/cfg/config_test.go
@@ -1,0 +1,172 @@
+package cfg_test
+
+import (
+	"code.cloudfoundry.org/capi-k8s-release/src/cf-api-controllers/cfg"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+)
+
+var _ = Describe("Config", func() {
+	Describe("Load", func() {
+		const (
+			expectedCFAPIHost               = "api.cloudfoundry.example.com"
+			expectedUAAEndpoint             = "uaa.cloudfoundry.example.com"
+			expectedUAAClientName           = "example-uaa-client-name"
+			expectedWorkloadsNamespace      = "example-cf-workloads"
+			expectedUAAClientSecretFromEnv  = "uaa-client-secret-from-env"
+			expectedUAAClientSecretFromFile = "uaa-client-secret-from-file"
+		)
+
+		BeforeEach(func() {
+			err := os.Setenv("CF_API_HOST", expectedCFAPIHost)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Setenv("UAA_ENDPOINT", expectedUAAEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Setenv("UAA_CLIENT_NAME", expectedUAAClientName)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Setenv("UAA_CLIENT_SECRET", expectedUAAClientSecretFromEnv)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Setenv("WORKLOADS_NAMESPACE", expectedWorkloadsNamespace)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("loads the config from env", func() {
+			config, err := cfg.Load()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(config.CFAPIHost()).To(Equal(expectedCFAPIHost))
+			Expect(config.UAAEndpoint()).To(Equal(expectedUAAEndpoint))
+			Expect(config.UAAClientName()).To(Equal(expectedUAAClientName))
+			Expect(config.UAAClientSecret()).To(Equal(expectedUAAClientSecretFromEnv))
+			Expect(config.WorkloadsNamespace()).To(Equal(expectedWorkloadsNamespace))
+		})
+
+		Context("when the CF_API_HOST env var is not set", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv("CF_API_HOST")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.Load()
+				Expect(err).To(MatchError("`CF_API_HOST` environment variable must be set"))
+			})
+		})
+
+		Context("when the UAA_ENDPOINT env var is not set", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv("UAA_ENDPOINT")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.Load()
+				Expect(err).To(MatchError("`UAA_ENDPOINT` environment variable must be set"))
+			})
+		})
+
+		Context("when the UAA_CLIENT_NAME env var is not set", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv("UAA_CLIENT_NAME")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.Load()
+				Expect(err).To(MatchError("`UAA_CLIENT_NAME` environment variable must be set"))
+			})
+		})
+
+		Context("when the WORKLOADS_NAMESPACE env var is not set", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv("WORKLOADS_NAMESPACE")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.Load()
+				Expect(err).To(MatchError("`WORKLOADS_NAMESPACE` environment variable must be set"))
+			})
+		})
+
+		Describe("loading UAA Client Secret", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv("UAA_CLIENT_SECRET_FILE")
+				Expect(err).NotTo(HaveOccurred())
+				err = os.Unsetenv("UAA_CLIENT_SECRET")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("when UAA_CLIENT_SECRET_FILE is set", func() {
+				Context("and the file can be read without error", func() {
+					var tempSecretFile *os.File
+
+					BeforeEach(func() {
+						var err error
+						tempSecretFile, err = ioutil.TempFile("", "fake-uaa-client-secret")
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = tempSecretFile.WriteString(expectedUAAClientSecretFromFile)
+						Expect(err).NotTo(HaveOccurred())
+
+						err = os.Setenv("UAA_CLIENT_SECRET_FILE", tempSecretFile.Name())
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					AfterEach(func() {
+						err := os.Remove(tempSecretFile.Name())
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("loads the client secret from the specified file", func() {
+						config, err := cfg.Load()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(config.UAAClientSecret()).To(Equal(expectedUAAClientSecretFromFile))
+					})
+				})
+
+				Context("and an error occurs while reading the file", func() {
+					BeforeEach(func() {
+						err := os.Setenv("UAA_CLIENT_SECRET_FILE", "hello-im-a-fake-file.zip")
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("returns an error", func() {
+						_, err := cfg.Load()
+						Expect(err).To(HaveOccurred())
+
+						_, ok := err.(*os.PathError)
+						Expect(ok).To(BeTrue())
+					})
+				})
+			})
+
+			Context("when UAA_CLIENT_SECRET_FILE is not set", func() {
+				Context("and UAA_CLIENT_SECRET is set", func() {
+					BeforeEach(func() {
+						err := os.Setenv("UAA_CLIENT_SECRET", expectedUAAClientSecretFromEnv)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("loads the client secret from the environment", func() {
+						config, err := cfg.Load()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(config.UAAClientSecret()).To(Equal(expectedUAAClientSecretFromEnv))
+					})
+				})
+
+				Context("UAA_CLIENT_SECRET is not set", func() {
+					It("returns an error", func() {
+						_, err := cfg.Load()
+						errMsg := "`UAA_CLIENT_SECRET_FILE` or `UAA_CLIENT_SECRET` environment variable must be set"
+						Expect(err).To(MatchError(errMsg))
+					})
+				})
+			})
+		})
+	})
+})

--- a/templates/controllers_deployment.yml
+++ b/templates/controllers_deployment.yml
@@ -35,8 +35,6 @@ spec:
           value: cf_api_controllers
         - name: CF_API_HOST
           value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
-        - name: STAGING_NAMESPACE
-          value: #@ data.values.staging_namespace
         - name: WORKLOADS_NAMESPACE
           value: #@ data.values.workloads_namespace
         resources:


### PR DESCRIPTION
We were loading config from the environment variables and files in several places. This change introduces a Config struct to consolidate where we load them and backfills some tests. Going forward we should aim to keep env variable accessing to this package.

I didn't implement `STAGING_NAMESPACE` because it did not appear to be used. Let me know if we actually do need it and I missed a spot. If we don't, I'll go ahead and remove it from the `cf-api-controllers` `Deployment` YAML as well.

CAPI chore with some more context: [#174848323](https://www.pivotaltracker.com/story/show/174848323)
