### PR TITLE
Update README.md to include architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-### Disclaimer
-This repo is very new, experimental, and not yet continuously integrated or tested to the degree we'd like.
+# capi-k8s-release
 
-### Pre-requisites
+This collection of yaml, ytt, and go code packages together the bits that make [the CF API](http://v3-apidocs.cloudfoundry.org/) run in [cf-for-k8s](https://github.com/cloudfoundry/cf-for-k8s/). 
 
-1. Clone the `cf-for-k8s` repository: https://github.com/cloudfoundry/cf-for-k8s/
-1. Install any prerequisites of `cf-for-k8s`: https://github.com/cloudfoundry/cf-for-k8s/blob/master/docs/deploy.md#prerequisites
+### Deploying
+
+1. capi-k8s-release is best consumed as part of [cf-for-k8s](https://github.com/cloudfoundry/cf-for-k8s/)
+1. Clone the `cf-for-k8s` repository: `git clone https://github.com/cloudfoundry/cf-for-k8s.git`
+1. Follow [the cf-for-k8s deploy documentation](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/deploy.md)
+  
+### Components & Collaborators
+
+![A Diagram of cf-for-k8s focused on the CF API](capi-k8s-release.png)
+[click here to edit the diagram, save as capi-k8s-release.png to persist changes](https://app.diagrams.net/?src=about#Hcloudfoundry%2Fcapi-k8s-release%2Fmaster%2Fcapi-k8s-release.png)
+
+In this repo:
+- [cf-api-controllers](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/cf-api-controllers) is a collection of kubebuilder controllers that synchronize the CF API and various k8s CRDs (Images, Builds, Routes, PeriodicSyncs, etc).
+- [registry-buddy](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/registry-buddy) is sidecar service to help ruby code communicate with container registries using [go-containerregistry](https://github.com/google/go-containerregistry).
+- [nginx](https://github.com/cloudfoundry/capi-k8s-release/tree/master/dockerfiles/nginx) is a custom-built nginx container including [the nginx upload module](https://github.com/vkholodkov/nginx-upload-module) for managing resumable multipart package uploads.
+- [backup-metadata](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/backup-metadata) is a velero hook to that collects metadata about resources currently stored in the CF API. 
+
+From elsewhere:
+- [cloud_controller_ng](https://github.com/cloudfoundry/cloud_controller_ng) is reference implementation of the [the V3 CF API](http://v3-apidocs.cloudfoundry.org/).
+- [eirini](https://github.com/cloudfoundry-incubator/eirini) is an adapter that lets Cloudfoundry Processes and Tasks run on Kubernetes
+- [kpack](https://github.com/pivotal/kpack) is a collection of CRDs and Controllers for building container images from source using [Cloud Native Buildpacks](https://buildpacks.io/features/)
+- [route controller & istio](https://github.com/cloudfoundry/cf-k8s-networking) are used by cf-for-k8s to manage Routes to apps and the service mesh between CF components
+- [uaa](https://github.com/cloudfoundry/uaa) is used to manage users and token verification
+- [cf](https://github.com/cloudfoundry/cli) is the eponymous CLI for interacting with the CF API. We support versions v7 and higher.
+
+### Rolling out development changes to capi-k8s-release
+
+1. `./scripts/rollout.sh` will take any local changes to `capi-k8s-release`, apply them to a local `cf-for-k8s` directory, and then deploy `cf-for-k8s`
+1. `./scripts/build-and-rollout.sh` will take local changes to `cloud_controller_ng` and the components in `capi-k8s-release/src`, build them with [kbld](https://get-kbld.io/), [pack](https://github.com/buildpacks/pack), and [paketo's ruby and go buildpacks](https://github.com/paketo-buildpacks), and then deploy them all those new images to cf-for-k8s. 
+
+Environment variables can be used with either script to override default local source directories and remote image repositories.
 
 ### Configuring pushes of buildpack apps
 
@@ -38,9 +66,3 @@ kpack:
     username: <username>
     password: <password>
 ```
-
-
-### Rolling out changes to CAPI
-
-1. `./scripts/rollout.sh` will take any local changes to `capi-k8s-release`, apply them to a local `cf-for-k8s` directory, and then deploy `cf-for-k8s`
-  - Local `cf-for-k8s` directory can be overriden by setting `CF_FOR_K8s_DIR`

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ In this repo:
 - [cf-api-controllers](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/cf-api-controllers) is a collection of kubebuilder controllers that synchronize the CF API and various k8s CRDs (Images, Builds, Routes, PeriodicSyncs, etc).
 - [registry-buddy](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/registry-buddy) is sidecar service to help ruby code communicate with container registries using [go-containerregistry](https://github.com/google/go-containerregistry).
 - [nginx](https://github.com/cloudfoundry/capi-k8s-release/tree/master/dockerfiles/nginx) is a custom-built nginx container including [the nginx upload module](https://github.com/vkholodkov/nginx-upload-module) for managing resumable multipart package uploads.
-- [backup-metadata](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/backup-metadata) is a velero hook to that collects metadata about resources currently stored in the CF API. 
+- [backup-metadata](https://github.com/cloudfoundry/capi-k8s-release/tree/master/src/backup-metadata) is a velero hook that collects metadata about resources currently stored in the CF API. 
 
 From elsewhere:
-- [cloud_controller_ng](https://github.com/cloudfoundry/cloud_controller_ng) is reference implementation of the [the V3 CF API](http://v3-apidocs.cloudfoundry.org/).
+- [cloud_controller_ng](https://github.com/cloudfoundry/cloud_controller_ng) is a reference implementation of the [the V3 CF API](http://v3-apidocs.cloudfoundry.org/).
 - [eirini](https://github.com/cloudfoundry-incubator/eirini) is an adapter that lets Cloudfoundry Processes and Tasks run on Kubernetes
 - [kpack](https://github.com/pivotal/kpack) is a collection of CRDs and Controllers for building container images from source using [Cloud Native Buildpacks](https://buildpacks.io/features/)
 - [route controller & istio](https://github.com/cloudfoundry/cf-k8s-networking) are used by cf-for-k8s to manage Routes to apps and the service mesh between CF components


### PR DESCRIPTION
- also include list of collaborator components with links
- remove disclaimer and link more aggressively to cf-for-k8s
- push config down to bottom of the document. when we add more of that type of info, we should probably break it out into a seperate doc.

[[#175080284]](https://www.pivotaltracker.com/story/show/175080284)