### PR TITLE
Switch statsd_exporter image to use the one from cloudfoundry dockerhub

### DIFF
--- a/values/images.yml
+++ b/values/images.yml
@@ -6,4 +6,4 @@ images:
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
   nginx: cloudfoundry/capi-nginx@sha256:25997cca011ed0761955754a68931f7b1694e487bffba73c6ac8dbcd084f5dee
   registry_buddy: cloudfoundry/cf-api-package-registry-buddy@sha256:bb13c6ffe7cab019f3ee35fc629e164fb7d6c6b7d36bd74a0b2ae66090207561
-  statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
+  statsd_exporter: cloudfoundry/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407


### PR DESCRIPTION
[#174735977]

Hi all, we've moved our statsd_exporter image to live under the Cloudfoundry docker.

slack: #logging-and-metrics