### PR TITLE
include arguments for detected start commands

### DIFF
--- a/src/cf-api-controllers/controllers/build_controller.go
+++ b/src/cf-api-controllers/controllers/build_controller.go
@@ -21,10 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"code.cloudfoundry.org/capi-k8s-release/src/cf-api-controllers/cf/model"
 	"code.cloudfoundry.org/capi-k8s-release/src/cf-api-controllers/image_registry"
 	"github.com/buildpacks/lifecycle"
+	"github.com/buildpacks/lifecycle/launch"
 	"github.com/go-logr/logr"
 	buildv1alpha1 "github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
@@ -152,9 +154,14 @@ func (r *BuildReconciler) extractProcessTypes(build *buildv1alpha1.Build) (map[s
 
 	ret := make(map[string]string)
 	for _, process := range buildMetadata.Processes {
-		ret[process.Type] = process.Command
+		ret[process.Type] = extractFullCommand(process)
 	}
 	return ret, nil
+}
+
+func extractFullCommand(process launch.Process) string {
+	commandWithArgs := append([]string{process.Command}, process.Args...)
+	return strings.Join(commandWithArgs, " ")
 }
 
 func (r *BuildReconciler) reconcileSuccessfulBuild(build *buildv1alpha1.Build, logger logr.Logger) (ctrl.Result, error) {

--- a/src/cf-api-controllers/controllers/build_controller_test.go
+++ b/src/cf-api-controllers/controllers/build_controller_test.go
@@ -35,6 +35,7 @@ var _ = Describe("BuildController", func() {
 			Processes: []launch.Process{{
 				Type:    "baz",
 				Command: "some-start-command",
+				Args:    []string{"-flag", "some-arg"},
 			}},
 		})
 		Expect(err).To(BeNil())
@@ -123,7 +124,7 @@ var _ = Describe("BuildController", func() {
 			Expect(actualBuildPatch.State).To(Equal(model.BuildStagedState))
 			Expect(actualBuildPatch.Lifecycle.Data.Image).To(Equal("foo.bar/here/be/an/image"))
 			Expect(actualBuildPatch.Lifecycle.Data.ProcessTypes).To(HaveLen(1))
-			Expect(actualBuildPatch.Lifecycle.Data.ProcessTypes).To(HaveKeyWithValue("baz", "some-start-command"))
+			Expect(actualBuildPatch.Lifecycle.Data.ProcessTypes).To(HaveKeyWithValue("baz", "some-start-command -flag some-arg"))
 		})
 
 		Context("when the build fails with a failed container", func() {

--- a/src/cf-api-controllers/go.sum
+++ b/src/cf-api-controllers/go.sum
@@ -304,6 +304,7 @@ github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGl
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 h1:yWHOI+vFjEsAakUTSrtqc/SAHrhSkmn48pqjidZX3QA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=


### PR DESCRIPTION
Discovered this behavior while working on https://github.com/cloudfoundry/cloud_controller_ng/pull/1917.

Previously if a `Procfile` specified a command like `bundle exec rackup config.ru -p $PORT` the controller would only send back the "Command portion" (`bundle`) back to Cloud Controller and omit the rest of the arguments.

See https://github.com/cloudfoundry/capi-k8s-release/issues/88 for more information on the issue / how to reproduce this, but with this change kpack-built droplets will now include the full detected start commands for each process type.

### Procfile used with `dora`
```
web: bundle exec rackup config.ru -p $PORT
worker: sleep 10000
foo: bundle exec rackup config.ru -p 8080
```

### Example Before Droplet
```json
{
   "guid": "5efc4402-ca92-4387-b0d0-91a6a21d2daf",
   "created_at": "2020-10-21T00:05:22Z",
   "updated_at": "2020-10-21T00:05:59Z",
   "state": "STAGED",
   "error": null,
   "lifecycle": {
      "type": "kpack",
      "data": {}
   },
   "checksum": null,
   "buildpacks": null,
   "stack": null,
   "image": "gcr.io/cf-capi-arya/cf-workloads/8eb4ed9a-3804-4a66-90b6-6db0fade796c@sha256:fe502f3bbc3efcd0bf3ae647c4c733e127f2dd3625c2aaabc07f1c13b5e6d25f",
   "execution_metadata": null,
   "process_types": {
      "foo": "bundle",
      "web": "bundle",
      "worker": "sleep"
   },
   "relationships": {
      "app": {
         "data": {
            "guid": "8eb4ed9a-3804-4a66-90b6-6db0fade796c"
         }
      }
   },
   "metadata": {
      "labels": {},
      "annotations": {}
   },
   "links": {
      "self": {
         "href": "https://api.tim.k8s.capi.land/v3/droplets/5efc4402-ca92-4387-b0d0-91a6a21d2daf"
      },
      "app": {
         "href": "https://api.tim.k8s.capi.land/v3/apps/8eb4ed9a-3804-4a66-90b6-6db0fade796c"
      },
      "assign_current_droplet": {
         "href": "https://api.tim.k8s.capi.land/v3/apps/8eb4ed9a-3804-4a66-90b6-6db0fade796c/relationships/current_droplet",
         "method": "PATCH"
      },
      "package": {
         "href": "https://api.tim.k8s.capi.land/v3/packages/e0bf1462-ba4b-48cb-aa78-9ac2f91900da"
      }
   }
}
```

### Example After Droplet
```json
{
   "guid": "a3f29dcb-e015-4992-90b9-65b7717d8172",
   "created_at": "2020-10-21T18:31:34Z",
   "updated_at": "2020-10-21T18:32:22Z",
   "state": "STAGED",
   "error": null,
   "lifecycle": {
      "type": "kpack",
      "data": {}
   },
   "checksum": null,
   "buildpacks": null,
   "stack": null,
   "image": "gcr.io/cf-capi-arya/cf-workloads/30f0dda9-d3f1-491e-bae7-05775e28c9b0@sha256:34e069236dab4849e243776572638594790b40d616430e4073e7c6dd1cc93e18",
   "execution_metadata": null,
   "process_types": {
      "foo": "bundle exec rackup config.ru -p 8080",
      "web": "bundle exec rackup config.ru -p $PORT",
      "worker": "sleep 10000"
   },
   "relationships": {
      "app": {
         "data": {
            "guid": "30f0dda9-d3f1-491e-bae7-05775e28c9b0"
         }
      }
   },
   "metadata": {
      "labels": {},
      "annotations": {}
   },
   "links": {
      "self": {
         "href": "https://api.tim.k8s.capi.land/v3/droplets/a3f29dcb-e015-4992-90b9-65b7717d8172"
      },
      "app": {
         "href": "https://api.tim.k8s.capi.land/v3/apps/30f0dda9-d3f1-491e-bae7-05775e28c9b0"
      },
      "assign_current_droplet": {
         "href": "https://api.tim.k8s.capi.land/v3/apps/30f0dda9-d3f1-491e-bae7-05775e28c9b0/relationships/current_droplet",
         "method": "PATCH"
      },
      "package": {
         "href": "https://api.tim.k8s.capi.land/v3/packages/4b46ce89-250b-420f-b22f-7d4890267b9f"
      }
   }
}
```

CAKE Story: [#175367658](https://www.pivotaltracker.com/story/show/175367658)