### PR TITLE
Expose extra S3 config for resource pool's blobstore

### DIFF
--- a/templates/ccng-config.lib.yml
+++ b/templates/ccng-config.lib.yml
@@ -157,7 +157,7 @@ resource_pool:
   minimum_size: 65536
   maximum_size: 536870912
 
-  fog_aws_storage_options: {}
+  fog_aws_storage_options: #@ data.values.blobstore.fog_aws_storage_options
 
 packages:
   app_package_directory_key: #@ data.values.blobstore.package_directory_key

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -11,6 +11,7 @@ blobstore:
   region: ""
   resource_directory_key: cc-resources
   secret_access_key_secret_name:
+  fog_aws_storage_options: {}
 cc:
   log_level: info
 ccdb:


### PR DESCRIPTION
Allows for users to supply a pass-through value for `fog_aws_storage_options` to configure whatever they so desire for the fog connection to an S3 blobstore. This PR should be safe to merge and run against `cf-for-k8s` develop since it defaults to an empty hash just as it was before.

In order to actually expose this configuration to CF operators, you would have to do one of the following:

1. Add changes to cf-for-k8s to expose that configuration in their install values file and provide a modified values file like so:

    ```diff
    #@data/values
    ---
    system_domain: "jwal.k8s.capi.land"
    cf_admin_password: ...

    blobstore:
      secret_access_key: ...
    +   #@overlay/match-child-defaults missing_ok=True
    +   fog_aws_storage_options:
    +     encryption: "AES256"

    cf_db:
      admin_password: ...
    ```

1. Make no changes to cf-for-k8s and require that operators supply an additional data values file when deploying CF like so:

    ```yaml
    #@library/ref "@capi-k8s-release"
    #@data/values after_library_module=True
    ---
    blobstore:
      #@overlay/match-child-defaults missing_ok=True
      fog_aws_storage_options:
        encryption: "AES256"
    ```

    and deploy with that additional values file: `kapp deploy -a cf -f <(ytt -f config/ -f install-values.yml -f that-additional-data-values-file.yml)`