### PR TITLE
Update `backup-metadata` to use client credentials instead of user auth with UAA

### DIFF
--- a/src/backup-metadata/config/cfmetadata.yml
+++ b/src/backup-metadata/config/cfmetadata.yml
@@ -27,14 +27,14 @@ spec:
         name: cf-metadata
         command: ["/cnb/process/wait"]
         env:
-        - name: CF_API
+        - name: CF_API_HOST
           value: #@ data.values.cf.api
-        - name: CF_USER
+        - name: CF_CLIENT
           valueFrom:
             secretKeyRef:
               key: username
               name: cf-credentials-cf-metadata
-        - name: CF_PASSWORD
+        - name: CF_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               key: password

--- a/src/backup-metadata/internal/cfmetadata/client.go
+++ b/src/backup-metadata/internal/cfmetadata/client.go
@@ -30,11 +30,11 @@ type Client struct {
 	CfClient cfclient.CloudFoundryClient
 }
 
-func NewClient(apiAddress string, userName string, password string) (*Client, error) {
+func NewClient(apiAddress string, clientID string, clientSecret string) (*Client, error) {
 	conf := &cfclient.Config{
 		ApiAddress:        apiAddress,
-		Username:          userName,
-		Password:          password,
+		ClientID:          clientID,
+		ClientSecret:      clientSecret,
 		SkipSslValidation: true,
 	}
 

--- a/src/backup-metadata/internal/delegate/main.go
+++ b/src/backup-metadata/internal/delegate/main.go
@@ -18,25 +18,25 @@ const (
 )
 
 func Main(args []string, input Reader, env map[string]string) error {
-	cfAPI := env["CF_API"]
-	cfUsername := env["CF_USER"]
-	cfPassword := env["CF_PASSWORD"]
+	cfAPI := env["CF_API_HOST"]
+	cfClient := env["CF_CLIENT"]
+	cfClientSecret := env["CF_CLIENT_SECRET"]
 
 	if cfAPI == "" {
-		return fmt.Errorf("CF_API Environment is not set")
+		return fmt.Errorf("'CF_API_HOST' Environment Variable is not set")
 	}
 
-	if cfUsername == "" {
-		return fmt.Errorf("CF_USER Environment is not set")
+	if cfClient == "" {
+		return fmt.Errorf("'CF_CLIENT' Environment Variable is not set")
 	}
 
-	if cfPassword == "" {
-		return fmt.Errorf("CF_PASSWORD Environment is not set")
+	if cfClientSecret == "" {
+		return fmt.Errorf("'CF_CLIENT_SECRET' Environment Variable is not set")
 	}
 
 	switch len(args) {
 	case reportMetadata:
-		err := printMetadata(cfAPI, cfUsername, cfPassword)
+		err := printMetadata(cfAPI, cfClient, cfClientSecret)
 		if err != nil {
 			return err
 		}
@@ -45,7 +45,7 @@ func Main(args []string, input Reader, env map[string]string) error {
 			return fmt.Errorf("unknown option: %s, Did you mean compare ?", args[1])
 		}
 
-		if err := printComparison(cfAPI, cfUsername, cfPassword, input); err != nil {
+		if err := printComparison(cfAPI, cfClient, cfClientSecret, input); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
This updates the CF client to use authenticate with UAA client credentials instead of user auth and renames environment variables to reflect this.

CAKE Story: [#175469923](https://www.pivotaltracker.com/story/show/175469923)