### PR TITLE
scale memory on eirini & kpack components when scale testing

### DIFF
--- a/overlays/scale-testing.yml
+++ b/overlays/scale-testing.yml
@@ -3,26 +3,68 @@
 #@overlay/match by=overlay.subset({ "kind" : "Deployment", "metadata": { "name" : "eirini" }})
 ---
 spec:
-  #@overlay/match missing_ok=True
-  replicas: 10
+ #@overlay/match missing_ok=True
+ replicas: 10
 
 #@overlay/match by=overlay.subset({ "kind" : "Deployment", "metadata": { "name" : "eirini-controller" }})
 ---
 spec:
-  #@overlay/match missing_ok=True
-  replicas: 10
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: eirini-controller
+        #@overlay/match missing_ok=True
+        resources:
+          requests:
+            memory: 600Mi
+          limits:
+            memory: 1Gi
 
 #@overlay/match by=overlay.subset({ "kind" : "Deployment", "metadata": { "name" : "eirini-events" }})
 ---
 spec:
-  #@overlay/match missing_ok=True
-  replicas: 10
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: event-reporter
+        #@overlay/match missing_ok=True
+        resources:
+          requests:
+            memory: 600Mi
+          limits:
+            memory: 1Gi
 
 #@overlay/match by=overlay.subset({ "kind" : "Deployment", "metadata": { "name" : "eirini-task-reporter" }})
 ---
 spec:
-  #@overlay/match missing_ok=True
-  replicas: 10
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: task-reporter
+        #@overlay/match missing_ok=True
+        resources:
+          requests:
+            memory: 600Mi
+          limits:
+            memory: 1Gi
+
+#@overlay/match by=overlay.subset({ "kind" : "Deployment", "metadata": { "name" : "kpack-controller" }})
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: controller
+        #@overlay/match missing_ok=True
+        resources:
+          requests:
+            memory: 1Gi
+          limits:
+            memory: 2Gi
 
 #! Modify these values to adjust scaling characteristics
 #@ ingress_gateway_replicas = 2


### PR DESCRIPTION
previously we were increasing the instance counts of these components but they would crash anyways. I think they're probably single-instance-and-vertical-scale-only.