### PR TITLE
colocate backup-metadata container with cf-api-controllers

### DIFF
--- a/dev-templates/_dev-values.yml
+++ b/dev-templates/_dev-values.yml
@@ -4,8 +4,10 @@ kbld:
   destination:
     ccng: ""
     cf_api_controllers: ""
+    backup_metadata: ""
     registry_buddy: ""
 src_dirs:
   ccng: ""
   cf_api_controllers: ""
+  backup_metadata: ""
   registry_buddy: ""

--- a/dev-templates/kbld.yml
+++ b/dev-templates/kbld.yml
@@ -27,6 +27,18 @@ sources:
   - imageRepo: #@ data.values.kbld.destination.registry_buddy
     path: #@ data.values.src_dirs.registry_buddy
     pack: *packConfig
+  - imageRepo: cloudfoundry/cf-api-backup-metadata-generator
+    path: #@ data.values.src_dirs.backup_metadata
+    pack: &goWithProcfilePackConfig
+      build:
+        builder: paketobuildpacks/builder:full
+        buildpacks:
+          - gcr.io/paketo-buildpacks/go
+          - gcr.io/paketo-buildpacks/procfile
+        rawOptions: ["--default-process", "wait"]
+  - imageRepo: #@ data.values.kbld.destination.backup_metadata
+    path: #@ data.values.src_dirs.backup_metadata
+    pack: *goWithProcfilePackConfig
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: ImageDestinations
@@ -43,6 +55,10 @@ destinations:
     newImage: #@ data.values.kbld.destination.registry_buddy
   - imageRepo: #@ data.values.kbld.destination.registry_buddy
     newImage: #@ data.values.kbld.destination.registry_buddy
+  - imageRepo: cloudfoundry/cf-api-backup-metadata-generator
+    newImage: #@ data.values.kbld.destination.backup_metadata
+  - imageRepo: #@ data.values.kbld.destination.backup_metadata
+    newImage: #@ data.values.kbld.destination.backup_metadata
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: ImageKeys
@@ -50,6 +66,7 @@ keys:
 - ccng
 - cf_api_controllers
 - registry_buddy
+- backup_metadata
 ---
 apiVersion: kbld.k14s.io/v1alpha1
 kind: Config

--- a/scripts/build-into-values.sh
+++ b/scripts/build-into-values.sh
@@ -9,11 +9,13 @@ REPO_BASE_DIR="${SCRIPT_DIR}/.."
 IMAGE_DESTINATION_CCNG="${IMAGE_DESTINATION_CCNG:-gcr.io/cf-capi-arya/dev-ccng}"
 IMAGE_DESTINATION_CF_API_CONTROLLERS="${IMAGE_DESTINATION_CF_API_CONTROLLERS:-gcr.io/cf-capi-arya/dev-controllers}"
 IMAGE_DESTINATION_REGISTRY_BUDDY="${IMAGE_DESTINATION_REGISTRY_BUDDY:-gcr.io/cf-capi-arya/dev-registry-buddy}"
+IMAGE_DESTINATION_BACKUP_METADATA="${IMAGE_DESTINATION_BACKUP_METADATA:-gcr.io/cf-capi-arya/dev-backup-metadata}"
 CF_FOR_K8s_DIR="${CF_FOR_K8s_DIR:-${HOME}/workspace/cf-for-k8s/}"
 CAPI_RELEASE_DIR="${CAPI_RELEASE_DIR:-${HOME}/workspace/capi-release/}"
 CCNG_DIR="${CAPI_RELEASE_DIR}src/cloud_controller_ng"
 CF_API_CONTROLLERS_DIR="${CAPI_CF_API_CONTROLLERS_DIR:-${REPO_BASE_DIR}/src/cf-api-controllers}"
 REGISTRY_BUDDY_DIR="${REGISTRY_BUDDY_DIR:-${REPO_BASE_DIR}/src/registry-buddy}"
+BACKUP_METADATA_DIR="${BACKUP_METADATA_DIR:-${REPO_BASE_DIR}/src/backup-metadata}"
 
 if [ -z "$1" ]
   then
@@ -27,9 +29,11 @@ ytt -f "${REPO_BASE_DIR}/dev-templates/" \
     -v "kbld.destination.ccng=${IMAGE_DESTINATION_CCNG}" \
     -v "kbld.destination.cf_api_controllers=${IMAGE_DESTINATION_CF_API_CONTROLLERS}" \
     -v "kbld.destination.registry_buddy=${IMAGE_DESTINATION_REGISTRY_BUDDY}" \
+    -v "kbld.destination.backup_metadata=${IMAGE_DESTINATION_BACKUP_METADATA}" \
     -v "src_dirs.ccng=${CCNG_DIR}" \
     -v "src_dirs.cf_api_controllers=${CF_API_CONTROLLERS_DIR}" \
     -v "src_dirs.registry_buddy=${REGISTRY_BUDDY_DIR}" \
+    -v "src_dirs.backup_metadata=${BACKUP_METADATA_DIR}" \
      > "${KBLD_TMP}"
 
 # build a new values file with kbld

--- a/templates/controllers_deployment.yml
+++ b/templates/controllers_deployment.yml
@@ -19,6 +19,9 @@ spec:
       app.kubernetes.io/name: cf-api-controllers
   template:
     metadata:
+      annotations:
+        pre.hook.backup.velero.io/container: backup-metadata-generator
+        pre.hook.backup.velero.io/command: '["/cnb/process/generate-metadata"]'
       labels:
         app.kubernetes.io/name: cf-api-controllers
     spec:
@@ -47,6 +50,27 @@ spec:
         volumeMounts:
           - name: uaa-client-secret
             mountPath: /config/uaa_client_secret
+      - name: backup-metadata-generator
+        image: #@ data.values.images.backup_metadata
+        imagePullPolicy: Always
+        command: [ "/cnb/process/wait" ]
+        env:
+        - name: CF_API_HOST
+          value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
+        - name: CF_CLIENT
+          value: cf_api_controllers
+        - name: CF_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: #@ data.values.uaa.clients.cf_api_controllers.secret_name
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
       volumes:
         - name: uaa-client-secret
           secret:

--- a/values/_default.yml
+++ b/values/_default.yml
@@ -61,4 +61,5 @@ images:
   nginx:
   statsd_exporter:
   registry_buddy:
+  backup_metadata:
 temporary_disable_v2_staging: true

--- a/values/images.yml
+++ b/values/images.yml
@@ -1,6 +1,7 @@
 #@data/values
 ---
 images:
+  backup_metadata: cloudfoundry/cf-api-backup-metadata-generator@sha256:b4a76bd7ea43782e2e0d624d86c6d04175ca5c5e6a29ff0210179a96a21e6d9c
   ccng: cloudfoundry/cloud-controller-ng@sha256:af245cae10e0fe8d89a3df78a83b2671f06aeb911d7db1857703b4fe326b7e95
   cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:3e160806f070af538eca6f04f6b3ee6a95f6b3247946e6961a0c976c18848243
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0


### PR DESCRIPTION
- Simplifies the installation process by no longer requiring a standalone
Deployment and configuration
- cf-api-controllers was chosen because it is already expected to have
network access to the cf-api-server Pods
- Switches to using kbld and the cloudfoundry/cf-api-backup-metadata-generator repo
for building/storing the backup-metadata image

See [this doc](https://docs.google.com/document/d/1aR6_v0wTrSWpH9G2XqHcUTsdCNzP82ZsiWUxiN-4Zno/edit#) for more information.

CAKE Story: [#175080281](https://www.pivotaltracker.com/story/show/175080281)