### PR TITLE
make backup-metadata binary tests support client credentials

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run unit tests
         run: |
           cd src/backup-metadata/
-          go test -v ./internal/...
+          go test -v ./internal/... ./test/binary/...
   template-tests:
     runs-on: ubuntu-latest
     container:

--- a/src/backup-metadata/test/binary/cf_metadata_compare_test.go
+++ b/src/backup-metadata/test/binary/cf_metadata_compare_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Compare", func() {
 	When("There is no difference in CF State", func() {
 		It("should report no changes", func() {
 			command := exec.Command(pathToBinary, "compare") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 			writeToPipe(command, getFileContents("fixtures/cf_state/metadata.json"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -37,7 +37,7 @@ var _ = Describe("Compare", func() {
 	When("There is a difference between CF State", func() {
 		It("should report newly added items", func() {
 			command := exec.Command(pathToBinary, "compare") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 			writeToPipe(command, getFileContents("fixtures/comparer/compare_json/current-minus-app.json"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -50,7 +50,7 @@ var _ = Describe("Compare", func() {
 
 		It("should report deleted items", func() {
 			command := exec.Command(pathToBinary, "compare") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 			writeToPipe(command, getFileContents("fixtures/comparer/compare_json/current-plus-app.json"))
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -66,7 +66,7 @@ var _ = Describe("Compare", func() {
 	When("the input JSON is invalid", func() {
 		It("returns a helpful error", func() {
 			command := exec.Command(pathToBinary, "compare") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 			writeToPipe(command, "This is }not{ JSON.")
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -80,7 +80,7 @@ var _ = Describe("Compare", func() {
 	When("the input JSON is not a CF-metadata JSON", func() {
 		It("should report it", func() {
 			command := exec.Command(pathToBinary, "compare") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 			writeToPipe(command, `{"foo": "bar"}`)
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -94,7 +94,7 @@ var _ = Describe("Compare", func() {
 	When("an unknown option is passed", func() {
 		It("should report an error", func() {
 			command := exec.Command(pathToBinary, "compareee") // #nosec
-			command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+			command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/backup-metadata/test/binary/input_parsing_test.go
+++ b/src/backup-metadata/test/binary/input_parsing_test.go
@@ -16,7 +16,7 @@ var _ = Describe("CF Backup Metadata inputs", func() {
 	When("Invalid arguments has been passed", func() {
 		It("should report an error when invalid number of arguments in passed", func() {
 			command := interactiveShell(pathToBinary, "compare", "hello", "world") // #nosec
-			command.Env = []string{"CF_API=DUMMY_API", "CF_USER=DUMMY_USER", "CF_PASSWORD=DUMMY_PASSWORD"}
+			command.Env = []string{"CF_API_HOST=FAKE_API", "CF_CLIENT=FAKE_CLIENT", "CF_CLIENT_SECRET=FAKE_PASSWORD"}
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -37,14 +37,14 @@ var _ = Describe("CF Backup Metadata inputs", func() {
 			Eventually(session).Should(gexec.Exit(1))
 			Eventually(session.Err).Should(gbytes.Say(expectedError))
 		},
-		Entry("CF_PASSWORD not set",
-			[]string{"CF_API=DUMMY_API", "CF_USER=DUMMY_USER"},
-			"CF_PASSWORD Environment is not set"),
-		Entry("CF_USER not set",
-			[]string{"CF_API=DUMMY_API", "CF_PASSWORD=DUMMY_PASSWORD"},
-			"CF_USER Environment is not set"),
-		Entry("CF_API not set",
-			[]string{"CF_PASSWORD=DUMMY_PASSWORD", "CF_USER=DUMMY_USER"},
-			"CF_API Environment is not set"),
+		Entry("CF_CLIENT_SECRET not set",
+			[]string{"CF_API_HOST=FAKE_API", "CF_CLIENT=FAKE_CLIENT"},
+			"'CF_CLIENT_SECRET' Environment Variable is not set"),
+		Entry("CF_CLIENT not set",
+			[]string{"CF_API_HOST=FAKE_API", "CF_CLIENT_SECRET=FAKE_PASSWORD"},
+			"'CF_CLIENT' Environment Variable is not set"),
+		Entry("CF_API_HOST not set",
+			[]string{"CF_CLIENT_SECRET=FAKE_PASSWORD", "CF_CLIENT=FAKE_CLIENT"},
+			"'CF_API_HOST' Environment Variable is not set"),
 	)
 })

--- a/src/backup-metadata/test/binary/metadata_retrieval_test.go
+++ b/src/backup-metadata/test/binary/metadata_retrieval_test.go
@@ -22,7 +22,7 @@ var _ = Describe("CF Metadata Retrieval", func() {
 		defer testServer.Close()
 
 		command := interactiveShell(pathToBinary) // #nosec
-		command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+		command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -35,7 +35,7 @@ var _ = Describe("CF Metadata Retrieval", func() {
 		defer testServer.Close()
 
 		command := interactiveShell(pathToBinary) // #nosec
-		command.Env = []string{"CF_API=" + testServer.URL, "CF_USER=" + cfUser, "CF_PASSWORD=" + cfPassword}
+		command.Env = []string{"CF_API_HOST=" + testServer.URL, "CF_CLIENT=" + cfClient, "CF_CLIENT_SECRET=" + cfClientSecret}
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- this set of tests was missed in the previous PR to make backup-metadata use UAA client credentials (https://github.com/cloudfoundry/capi-k8s-release/pull/95)
- updates the Github Action to run these tests as well

CAKE Story: [#175469923](https://www.pivotaltracker.com/story/show/175469923)