### PR TITLE
backup-metadata now uses its own UAA client

### DIFF
--- a/templates/controllers_deployment.yml
+++ b/templates/controllers_deployment.yml
@@ -58,12 +58,12 @@ spec:
         - name: CF_API_HOST
           value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
         - name: CF_CLIENT
-          value: cf_api_controllers
+          value: cf_api_backup_metadata_generator
         - name: CF_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               key: password
-              name: #@ data.values.uaa.clients.cf_api_controllers.secret_name
+              name: #@ data.values.uaa.clients.cf_api_backup_metadata_generator.secret_name
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
**DO NOT MERGE** until https://github.com/cloudfoundry/cf-for-k8s/pull/559/ is on `main` in cf-for-k8s.

See related cf-for-k8s PRs:
- https://github.com/cloudfoundry/cf-for-k8s/pull/559/
- https://github.com/cloudfoundry/cf-for-k8s/pull/555/

CAKE Story: [#175469923](https://www.pivotaltracker.com/story/show/175469923)
