### PR TITLE
add wrapper scripts for interacting with backup-metadata-generator

### DIFF
--- a/src/backup-metadata-generator/bin/compare-backup-metadata.sh
+++ b/src/backup-metadata-generator/bin/compare-backup-metadata.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+      echo "Usage: compare-backup-metadata file [namespace]"
+      echo "file - backup metadata json obtained from get-backup-metadata tool"
+      exit 1
+fi
+
+if [ -z "${2:-}" ]; then
+      NAMESPACE="";
+else
+      NAMESPACE="-n $2";
+      kubectl get namespace "$2" || exit 1
+fi
+
+POD_NAME=$(kubectl $NAMESPACE get pods -l 'app.kubernetes.io/name=cf-api-controllers' -o jsonpath='{.items[0].metadata.name}' 2> /dev/null)
+kubectl ${NAMESPACE} exec -i "${POD_NAME}" -c backup-metadata-generator -- bash -ce '/cnb/lifecycle/launcher backup-metadata-generator compare' < "$1"

--- a/src/backup-metadata-generator/bin/get-backup-metadata.sh
+++ b/src/backup-metadata-generator/bin/get-backup-metadata.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+   echo "Usage: get-backup-metadata veleroBackupName [file]"
+   echo "file - file name where metadata is output to"
+   exit 1
+fi
+
+if ! command -v velero &> /dev/null
+then
+    echo "velero is not installed. Please install velero and re-run this script."
+    exit 1
+fi
+
+if [ -z "${2:-}" ]; then
+   velero backup logs "$1" | grep -o 'CF Metadata: {.*}\\n'  \
+     | sed 's/CF Metadata: //g' \
+     | sed 's/\\n//g' \
+     | sed 's/\\//g' \
+     | jq .
+else
+   velero backup logs "$1" | grep -o 'CF Metadata: {.*}\\n'  \
+     | sed 's/CF Metadata: //g' \
+     | sed 's/\\n//g' \
+     | sed 's/\\//g' \
+     | jq . > "$2"
+fi
+

--- a/src/backup-metadata-generator/test/e2e/e2e_test.go
+++ b/src/backup-metadata-generator/test/e2e/e2e_test.go
@@ -3,7 +3,9 @@ package e2e_test
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"os"
 	"os/exec"
 	"strconv"
 	"time"
@@ -15,6 +17,14 @@ import (
 )
 
 var _ = Describe("e2e", func() {
+	var cfMetadataFile *os.File
+
+	AfterEach(func() {
+		if cfMetadataFile != nil {
+			os.Remove(cfMetadataFile.Name())
+		}
+	})
+
 	It("Assert CF metadata structure", func() {
 		backupName := generateRandomName()
 		createBackup(backupName)
@@ -29,6 +39,10 @@ var _ = Describe("e2e", func() {
 		Expect(metadata.Totals.Users).Should(BeNumerically(">=", 0))
 		Expect(metadata.Totals.Apps).Should(BeNumerically(">=", 0))
 		Expect(len(metadata.Orgs)).Should(BeNumerically(">=", 1))
+
+		cfMetadataFile = tmpOutputFile(cfMetadataJSON)
+		comparison := compareBackup(cfMetadataFile.Name())
+		Expect(comparison).To(MatchRegexp("No differences found|totals"))
 	})
 })
 
@@ -46,14 +60,34 @@ func createBackup(backupName string) {
 	fmt.Printf("Creating velero backup: %s \n", backupName)
 
 	_, err := exec.Command("velero", "backup", "create", "--wait", backupName).Output()
-	Expect(err).Should(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func getCFMetadataFromBackupLogs(backupName string) string {
-	command := "velero backup logs " + backupName + " | grep -oP '(?<=CF Metadata: ){.*}(?=\\\\n)' | xargs echo"
+	command := "../../bin/get-backup-metadata.sh " + backupName + " /dev/stdout"
 
 	backupLogs, err := exec.Command("bash", "-c", command).Output()
-	Expect(err).Should(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	return string(backupLogs)
+}
+
+func compareBackup(filePath string) string {
+	command := fmt.Sprintf("../../bin/compare-backup-metadata.sh %s cf-system", filePath)
+
+	comparison, err := exec.Command("bash", "-c", command).CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+
+	return string(comparison)
+}
+
+func tmpOutputFile(content string) *os.File {
+	file, err := ioutil.TempFile(os.TempDir(), "backup-e2e")
+	Expect(err).NotTo(HaveOccurred())
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	Expect(err).NotTo(HaveOccurred())
+
+	return file
 }


### PR DESCRIPTION
- these scripts are referred to by the following docs:
  https://github.com/pivotal-cf/docs-tas-kubernetes/blob/789fc839b649e754e0478ff946eafb6f3adb2eb2/bandr-restore-manual.html.md.erb#L229-L230
- also updates the e2e tests to test the basic functionality of these
- they come from here https://github.com/pivotal/cf-for-k8s-disaster-recovery/blob/master/backup-metadata/bin/get-backup-metadata.sh and have been adapted to work with our changes to the utility

CAKE Story: [#175080281](https://www.pivotaltracker.com/story/show/175080281)