### PR TITLE
use startupProbe instead of readinessProbe for rake-task based containers

### DIFF
--- a/templates/api_server_deployment.yml
+++ b/templates/api_server_deployment.yml
@@ -84,9 +84,6 @@ spec:
         - name: registry-buddy
           image: #@ data.values.images.registry_buddy
           imagePullPolicy: Always
-          readinessProbe:
-            tcpSocket:
-              port: 8080
           volumeMounts:
           - name: tmp-packages
             mountPath: /tmp/packages

--- a/templates/clock_deployment.yml
+++ b/templates/clock_deployment.yml
@@ -29,6 +29,8 @@ spec:
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
           command: [ "/cnb/process/clock" ]
+          ports:
+          - containerPort: 4446
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -41,7 +43,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: 4446
             periodSeconds: 3

--- a/templates/deployment_updater_deployment.yml
+++ b/templates/deployment_updater_deployment.yml
@@ -29,6 +29,8 @@ spec:
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
           command: [ "/cnb/process/deployment-updater" ]
+          ports:
+          - containerPort: 4445
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -41,7 +43,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: 4445
             periodSeconds: 3

--- a/templates/worker_deployment.yml
+++ b/templates/worker_deployment.yml
@@ -25,6 +25,8 @@ spec:
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
           command: [ "/cnb/process/api-worker" ]
+          ports:
+          - containerPort: 4444
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -37,7 +39,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: 4444
             periodSeconds: 3
@@ -52,9 +54,6 @@ spec:
         - name: registry-buddy
           image: #@ data.values.images.registry_buddy
           imagePullPolicy: Always
-          readinessProbe:
-            tcpSocket:
-              port: 8080
           env:
             - name: REGISTRY_USERNAME
               valueFrom:


### PR DESCRIPTION
- these jobs briefly listen on a socket while starting up, but do not maintain that socket long-term
  - this is done [here](https://github.com/cloudfoundry/cloud_controller_ng/blob/d7f2377d0f0903cf3342f8e3f98b4353cac4c2cb/lib/cloud_controller/background_job_environment.rb#L27)
  - alternatively I could update them to run a long-lived TCP server in a background thread, but since the processes aren't actually webserves that feels like just a more complicated process liveness check
  - if the `rake` tasks crash Kubernetes will detect this on its own and restart the container. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#when-should-you-use-a-liveness-probe
- these jobs run rake tasks that will crash when something goes wrong, so the regular liveness/readiness behavior of Kubernetes should suffice
- this was "working" previously because the readiness check probe was connecting to the Istio sidecar instead of the rake task, we noticed issues once switching to a non-mesh ingress solution (like Contour)
- removed the `readinessProbe` entirely from the `registry-buddy` since it does not accept external connections by design

Addresses https://github.com/cloudfoundry/capi-k8s-release/issues/91
Tracker Story: [#175388005](https://www.pivotaltracker.com/story/show/175388005)