### PR TITLE
Adjust default memory/cpu requests and limits

### DIFF
--- a/config/api_server_deployment.yml
+++ b/config/api_server_deployment.yml
@@ -40,10 +40,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 300Mi
+              memory: 500Mi
             limits:
               cpu: 1000m
-              memory: 1.2Gi
+              memory: 4Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
           - name: server-sock
@@ -68,10 +68,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 250Mi
             limits:
               cpu: 500m
-              memory: 1.2Gi
+              memory: 1Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
           - name: nginx-uploads
@@ -87,10 +87,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 15Mi
+              memory: 100Mi
             limits:
-              cpu: 15000m
-              memory: 150Mi
+              cpu: 1500m
+              memory: 1Gi
           volumeMounts:
           - name: tmp-packages
             mountPath: /tmp/packages
@@ -118,9 +118,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 250Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 1Gi
           volumeMounts:
           - name: nginx
@@ -140,7 +140,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 100Mi
             limits:
               cpu: 500m
               memory: 1Gi

--- a/config/ccdb-migrate-job.yaml
+++ b/config/ccdb-migrate-job.yaml
@@ -29,7 +29,7 @@ spec:
             memory: 300Mi
           limits:
             cpu: 1000m
-            memory: 1Gi
+            memory: 4Gi
         volumeMounts:
         - #@ template.replace(shared_config_volume_mounts())
         #@ if/end data.values.ccdb.ca_cert:

--- a/config/clock_deployment.yml
+++ b/config/clock_deployment.yml
@@ -39,10 +39,10 @@ spec:
           resources:
             requests:
               cpu: 300m
-              memory: 300Mi
+              memory: 500Mi
             limits:
               cpu: 1000m
-              memory: 1Gi
+              memory: 4Gi
           readinessProbe:
             tcpSocket:
               port: 4446

--- a/config/controllers_deployment.yml
+++ b/config/controllers_deployment.yml
@@ -43,11 +43,11 @@ spec:
           value: #@ data.values.workloads_namespace
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         volumeMounts:
           - name: uaa-client-secret
             mountPath: /config/uaa_client_secret
@@ -68,7 +68,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 25Mi
           limits:
             cpu: 500m
             memory: 1Gi


### PR DESCRIPTION
There's been [evidence](https://github.com/cloudfoundry/cf-for-k8s/issues/632) that the Cloud Controller API and registry-buddy components have been getting OOMKilled under typical usage in production environments. This change adjusts the resource limits to be more in line with what our monit limits historically were in the capi-release BOSH release. E.g. https://github.com/cloudfoundry/capi-release/blob/6f9b4d5ec3ba46adf39d7de2d60e1b58a4511784/jobs/cloud_controller_ng/spec#L893

Some memory requests were adjusted up and down to better account for typical/min usage of these components.

This change also adjusts some of the CPU limits to be more generous for
critical processes such as nginx and the cf-api-controllers reconciler.

Overall there is a `+210Mi` increase in memory requests (only `+10` if you ignore the short-lived ccdb migration `Job`).

If operators want to tweak these values further they can follow [this approach in our vertical scaling docs](https://github.com/cloudfoundry/cf-for-k8s/blob/819bc1c981153df6801d07e747b6ef4809189d24/docs/platform_operators/scaling.md#vertical-scaling).

Tracker story: [#177468691](https://www.pivotaltracker.com/story/show/177468691)