### PR TITLE
Update periodic sync crd for Kubernetes 1.22

### DIFF
--- a/config/periodic-sync-crd.yml
+++ b/config/periodic-sync-crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
- apiextensions.k8s.io/v1beta1 -> apiextensions.k8s.io/v1