### PR TITLE
Fix #117 - Add longer health check timeout on register-buddy container

### DIFF
--- a/config/api_server_deployment.yml
+++ b/config/api_server_deployment.yml
@@ -112,6 +112,7 @@ spec:
               - --show-error
               - localhost:8080/healthz
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           volumeMounts:
           - name: tmp-packages
             mountPath: /tmp/packages

--- a/config/worker_deployment.yml
+++ b/config/worker_deployment.yml
@@ -80,6 +80,7 @@ spec:
               - --show-error
               - localhost:8080/healthz
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
Australia is a *loooong* way away from hub.docker.com, which causes the register-buddy sidecar to constantly crash as seen in #117. Every request to /healthz calls the external API service before responding, and 1 second timeout is simply not enough time.

Adding a 3 second check timeout here fixes the issue, vs the default liveness check timeout of 1 second.

```bash
➜  ~ /usr/bin/time curl -ivs http://127.0.0.1:8889/healthz
*   Trying 127.0.0.1:8889...
* Connected to 127.0.0.1 (127.0.0.1) port 8889 (#0)
> GET /healthz HTTP/1.1
> Host: 127.0.0.1:8889
> User-Agent: curl/7.77.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Thu, 27 Jan 2022 04:37:56 GMT
Date: Thu, 27 Jan 2022 04:37:56 GMT
< Content-Length: 0
Content-Length: 0

<
* Connection #0 to host 127.0.0.1 left intact
        1.98 real         0.00 user         0.00 sys
```